### PR TITLE
historical decomposition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Title: Bayesian Estimation of Structural Vector Autoregressive Models
 Description: Provides fast and efficient procedures for Bayesian analysis of Structural Vector Autoregressions. This package estimates a wide range of models, including homo-, heteroskedastic, and non-normal specifications. Structural models can be identified by adjustable exclusion restrictions, time-varying volatility, or non-normality. They all include a flexible three-level equation-specific local-global hierarchical prior distribution for the estimated level of shrinkage for autoregressive and structural parameters. Additionally, the package facilitates predictive and structural analyses such as impulse responses, forecast error variance and historical decompositions, forecasting, verification of heteroskedasticity, non-normality, and hypotheses on autoregressive parameters, as well as analyses of structural shocks, volatilities, and fitted values. Beautiful plots, informative summary functions, and extensive documentation including the vignette by Woźniak (2024) <doi:10.48550/arXiv.2410.15090> complement all this. The implemented techniques align closely with those presented in Lütkepohl, Shang, Uzeda, & Woźniak (2024) <doi:10.48550/arXiv.2404.11057>, Lütkepohl & Woźniak (2020) <doi:10.1016/j.jedc.2020.103862>, and Song & Woźniak (2021) <doi:10.1093/acrefore/9780190625979.013.174>. The 'bsvars' package is aligned regarding objects, workflows, and code structure with the R package 'bsvarSIGNs' by Wang & Woźniak (2024) <doi:10.32614/CRAN.package.bsvarSIGNs>, and they constitute an integrated toolset.
 Version: 3.2.0.9000
 Date: 2024-10-24
-Authors@R: person("Tomasz", "Woźniak", , "wozniak.tom@pm.me", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0003-2212-2378"))
+Authors@R: c(person("Tomasz", "Woźniak", , "wozniak.tom@pm.me", role = c("aut", "cre"),comment = c(ORCID = "0000-0003-2212-2378")),
+           person("Xiaolei", "Wang", , "adamwang15@gmail.com", role = c("ctb"), comment = c(ORCID = "0009-0005-6192-9061", "corrected C++ code for historical decompositions")))
 Maintainer: Tomasz Woźniak <wozniak.tom@pm.me>
 Imports: 
     Rcpp (>= 1.0.7),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Have a question, or suggestion, or wanna get in touch? Join the package [DISCUSS
 
 1. The model with Student-t structural shocks features now, an estimated equation-specific degrees-of-freedom parameter, see `specify_bsvar_t()` with verified normality using function `verify_identification()` [#84](https://github.com/bsvars/bsvars/issues/84)
 2. Updated C++ flags to the newest recommended setup as inspired by the PR [#103](https://github.com/bsvars/bsvars/pull/103) by [@haansn08](https://github.com/haansn08)
+3. Corrected C++ code for historical decompositions in PR [#108](https://github.com/bsvars/bsvars/pull/108) by [Adam Wang](https://github.com/adamwang15)
 
 # bsvars 3.2
 

--- a/R/compute_historical_decompositions.R
+++ b/R/compute_historical_decompositions.R
@@ -20,7 +20,7 @@
 #'
 #' @seealso \code{\link{estimate}}, \code{\link{normalise_posterior}}, \code{\link{summary}}
 #'
-#' @author Tomasz Woźniak \email{wozniak.tom@pm.me}
+#' @author Tomasz Woźniak \email{wozniak.tom@pm.me} and Xiaolei Wang \email{adamwang15@gmail.com}
 #' 
 #' @references 
 #' Kilian, L., & Lütkepohl, H. (2017). Structural VAR Tools, Chapter 4, In: Structural vector autoregressive analysis. Cambridge University Press.

--- a/README.Rmd
+++ b/README.Rmd
@@ -109,7 +109,7 @@ This beautiful logo can be reproduced in R using [this file](https://github.com/
 - presentations:
   - for students at [Szkoła Główna Handlowa](https://www.sgh.waw.pl/) given in Warsaw in December 2024 [featuring **bsvars** 3.2 and **bsvarSIGNs** 1.0.1](https://bsvars.org/2024-12-sgh/)]
   - at [Uniwersytet Warszawski](https://www.wne.uw.edu.pl/) given in Warsaw in December 2024  [featuring **bsvars** 3.2 and **bsvarSIGNs** 1.0.1](https://bsvars.org/2024-12-uwwne/)
-  - for students and researchers at [Uniwersytet Ekonomiczny w Krakowie](https://uek.krakow.pl/) given in Cracow in December 2024 [featuring **bsvars** 3.2 and **bsvarSIGNs** 1.0.1](https://bsvars.org/2024-12-uek/)
+  - for students and researchers at [Uniwersytet Ekonomiczny w Krakowie](https://uek.krakow.pl/) given in Kraków in December 2024 [featuring **bsvars** 3.2 and **bsvarSIGNs** 1.0.1](https://bsvars.org/2024-12-uek/)
   - for Bayesian Econometrics students at the University of Melbourne given in October 2024 [featuring **bsvars** 3.1](https://bsvars.org/2024-10-be24-bsvars/)
   - for the [QuantEcon](https://quantecon.org/) lab at the Australian National University given in August 2024 [featuring **bsvars** 3.1 and **bsvarSIGNs** 1.0.1](https://bsvars.org/2024-08-bsvars-QuantEcon/)
   - at Monash University given in August 2024 [featuring **bsvars** 3.1 and **bsvarSIGNs** 1.0](https://bsvars.org/2024-08-bsvars-monash/)

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ file](https://github.com/bsvars/bsvars/blob/master/inst/varia/bsvars_logo.R).
     Warsaw in December 2024 [featuring **bsvars** 3.2 and **bsvarSIGNs**
     1.0.1](https://bsvars.org/2024-12-uwwne/)
   - for students and researchers at [Uniwersytet Ekonomiczny w
-    Krakowie](https://uek.krakow.pl/) given in Cracow in December 2024
+    Krakowie](https://uek.krakow.pl/) given in Kraków in December 2024
     [featuring **bsvars** 3.2 and **bsvarSIGNs**
     1.0.1](https://bsvars.org/2024-12-uek/)
   - for Bayesian Econometrics students at the University of Melbourne

--- a/man/compute_historical_decompositions.Rd
+++ b/man/compute_historical_decompositions.Rd
@@ -61,5 +61,5 @@ Kilian, L., & Lütkepohl, H. (2017). Structural VAR Tools, Chapter 4, In: Struct
 \code{\link{estimate}}, \code{\link{normalise_posterior}}, \code{\link{summary}}
 }
 \author{
-Tomasz Woźniak \email{wozniak.tom@pm.me}
+Tomasz Woźniak \email{wozniak.tom@pm.me} and Xiaolei Wang \email{adamwang15@gmail.com}
 }

--- a/src/bsvarTOOLs.cpp
+++ b/src/bsvarTOOLs.cpp
@@ -211,9 +211,8 @@ arma::field<arma::cube> bsvars_hd (
       
       cube        hds_at_t(N, N, t + 1);
       for (int i = 0; i <= t; i++) {
-        posterior_irf_t = posterior_irf_T(s).slice(i);
-        hds_at_t.slice(i) = posterior_irf_t.each_row() %
-                            structural_shocks.slice(s).col(t - i).t();
+        posterior_irf_t   = posterior_irf_T(s).slice(i);
+        hds_at_t.slice(i) = posterior_irf_t.each_row() % structural_shocks.slice(s).col(t - i).t();
       } // END i loop
       
       aux_hds.slice(t) = sum(hds_at_t, 2);

--- a/src/bsvarTOOLs.cpp
+++ b/src/bsvarTOOLs.cpp
@@ -210,9 +210,10 @@ arma::field<arma::cube> bsvars_hd (
     for (int t=0; t<T; t++) {
       
       cube        hds_at_t(N, N, t + 1);
-      for (int i=0; i<t; i++) {
-        posterior_irf_t   = posterior_irf_T(s).slice(t - i - 1);
-        hds_at_t.slice(i) = posterior_irf_t.each_col() % structural_shocks.slice(s).col(i);
+      for (int i = 0; i <= t; i++) {
+        posterior_irf_t = posterior_irf_T(s).slice(i);
+        hds_at_t.slice(i) = posterior_irf_t.each_row() %
+                            structural_shocks.slice(s).col(t - i).t();
       } // END i loop
       
       aux_hds.slice(t) = sum(hds_at_t, 2);


### PR DESCRIPTION
Hey @donotdespair,

Seems like this fixes the historical decomposition problem bsvars/bsvarSIGNs#47! Can be tested with this script:

```R
set.seed(123)

devtools::load_all(".")

T <- 100
N <- 2
Y <- matrix(rnorm(T * N), nrow = T, ncol = N)

spec <- specify_bsvar$new(Y)
post <- estimate(spec, S = 100)

ss <- compute_structural_shocks(post)
Ess <- apply(ss, 1:2, mean)

hd <- compute_historical_decompositions(post)
Ehd <- apply(hd, 1:3, mean)
sumEhd <- apply(Ehd, 2:3, sum)

par(mfrow = c(2, 1))
plot(Ess[1, ], type = "l")
lines(sumEhd[1, ], col = "red")
plot(Ess[2, ], type = "l")
lines(sumEhd[2, ], col = "red")
```