### PR TITLE
Correction of student-t df sampling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,13 @@ Authors@R: c(person(
               email = "bruno.cavalcante@fgv.edu.br", 
               role = c("ctb"),
               comment = c(ORCID = "0009-0005-7252-7658", "corrected R code for HMSH forecasting")
+            ),
+           person(
+              given = "Fei", 
+              family ="Shang",
+              email = "sfmax2010@gmail.com", 
+              role = c("ctb"),
+              comment = c(ORCID = "0000-0003-1908-3275", "corrected C++ code for Student's t shocks")
             )
           )
 Maintainer: Tomasz Woźniak <wozniak.tom@pm.me>

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ Have a question, or suggestion, or wanna get in touch? Email us at [contact\@bsv
 11. Replaced forecast method with `generics::forecast` as suggested by [\@robjhyndman](https://github.com/robjhyndman). [#114](https://github.com/bsvars/bsvars/issues/114)
 12. Normalisation is now made through the generic and methods `normalise` [131](https://github.com/bsvars/bsvars/issues/131)
 13. Corrected R code for forecasting with HMSH models in PR [#136](https://github.com/bsvars/bsvars/pull/136) by [Bruno Cavalcante](https://github.com/brunolbcavalcante)
+14. Corrected C++ code for Student's t shocks in PR [#140](https://github.com/bsvars/bsvars/pull/140) by [Fei Shang](https://github.com/lcq110)
 
 # bsvars 3.2
 

--- a/src/sample_t.cpp
+++ b/src/sample_t.cpp
@@ -40,8 +40,8 @@ double log_kernel_df (
   const int T   = aux_lambda.n_elem;
   double lk_df  = 0;
   lk_df   -= T * lgamma(0.5 * aux_df);                        // lambda prior
-  lk_df   += 0.5 * T * aux_df * log(0.5 * (aux_df + 2));      // lambda prior
-  lk_df   -= 0.5 * (aux_df - 2) * accu(log(aux_lambda));      // lambda prior
+  lk_df   += 0.5 * T * aux_df * log(0.5 * (aux_df - 2));      // lambda prior
+  lk_df   -= 0.5 * (aux_df + 2) * accu(log(aux_lambda));      // lambda prior
   lk_df   -= 0.5 * (aux_df - 2) * accu(pow(aux_lambda, -1));  // lambda prior
   lk_df   -= 2 * log(aux_df - 1);                             // df prior
   


### PR DESCRIPTION
I think I found a typo in `src/sample_t.cpp`, in function `log_kernel_df()`. The current code has:
```
lk_df += 0.5 * T * aux_df * log(0.5 * (aux_df + 2));
lk_df -= 0.5 * (aux_df - 2) * accu(log(aux_lambda));
```
but it should be:
```
lk_df += 0.5 * T * aux_df * log(0.5 * (aux_df - 2));
lk_df -= 0.5 * (aux_df + 2) * accu(log(aux_lambda));
```

I tested this with simulated Student-t BSVAR data with known true df: the original package pushed df to the boundary 2 and also affect other parameters; after changing only these two terms, df were recovered normally. I have also rerun the full tasks with the fixed bsvars package, and the process is looking good, I will later check the final forecasting measures