### PR TITLE
Fix recursive forecasts for non-centred SV and Student-t specs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Authors@R: c(person(
               family ="Shang",
               email = "sfmax2010@gmail.com", 
               role = c("ctb"),
-              comment = c(ORCID = "0000-0003-1908-3275", "corrected C++ code for Student's t shocks")
+              comment = c(ORCID = "0000-0003-1908-3275", "corrected C++ code for Student's t shocks, corrected code for forecasting")
             )
           )
 Maintainer: Tomasz Woźniak <wozniak.tom@pm.me>

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Have a question, or suggestion, or wanna get in touch? Email us at [contact\@bsv
 12. Normalisation is now made through the generic and methods `normalise` [131](https://github.com/bsvars/bsvars/issues/131)
 13. Corrected R code for forecasting with HMSH models in PR [#136](https://github.com/bsvars/bsvars/pull/136) by [Bruno Cavalcante](https://github.com/brunolbcavalcante)
 14. Corrected C++ code for Student's t shocks in PR [#140](https://github.com/bsvars/bsvars/pull/140) by [Fei Shang](https://github.com/lcq110)
+15. Fix recursive forecasts for non-centred SV and Student-t specifications in PR [#140](https://github.com/bsvars/bsvars/pull/143) by [Fei Shang](https://github.com/lcq110)
 
 # bsvars 3.2
 

--- a/src/forecast.cpp
+++ b/src/forecast.cpp
@@ -148,10 +148,11 @@ arma::cube forecast_sigma2_sv (
         xx        = randn();
         if ( centred_sv ) {
           ht(n)     = posterior_rho(n, s) * ht(n) + posterior_omega(n, s) * xx;
+          forecasts_sigma2(n, h, s) = exp(ht(n));
         } else {
-          ht(n)     = posterior_omega(n, s) * (posterior_rho(n, s) * ht(n) + xx);
+          ht(n)     = posterior_rho(n, s) * ht(n) + xx;
+          forecasts_sigma2(n, h, s) = exp(posterior_omega(n, s) * ht(n));
         }
-        forecasts_sigma2(n, h, s) = exp(ht(n));
       } // END n loop
     } // END h loop
   } // END s loop
@@ -175,13 +176,10 @@ arma::cube forecast_lambda_t (
   cube            forecasts_lambda(N, horizon, S, fill::ones);
   
   for (int s=0; s<S; s++) {
-    for (int h=0; h<horizon; h++) {
-      vec df_s                  = posterior_df.col(s);
-      forecasts_lambda.slice(s).each_col()  %= df_s - 2;
-      for (int n=0; n<N; n++) {
-        forecasts_lambda.slice(s).row(n)  /= trans(chi2rnd( df_s(n), horizon ));
-      } // END n loop
-    } // END h loop
+    vec df_s = posterior_df.col(s);
+    for (int n=0; n<N; n++) {
+      forecasts_lambda.slice(s).row(n) = (df_s(n) - 2.0) / trans(chi2rnd(df_s(n), horizon));
+    } // END n loop
   } // END s loop
   
   return forecasts_lambda;


### PR DESCRIPTION
I found two issues in `src/forecast.cpp`.

### 1. Non-centred SV forecasts

The current code has:

```cpp
ht(n) = posterior_omega(n, s) *
        (posterior_rho(n, s) * ht(n) + xx);
forecasts_sigma2(n, h, s) = exp(ht(n));
```

This multiplies `omega` again at each forecast step. It should be:

```cpp
ht(n) = posterior_rho(n, s) * ht(n) + xx;
forecasts_sigma2(n, h, s) =
  exp(posterior_omega(n, s) * ht(n));
```

### 2. Student-t forecasts

The current code has:

```cpp
for (int s=0; s<S; s++) {
  for (int h=0; h<horizon; h++) {
    vec df_s = posterior_df.col(s);
    forecasts_lambda.slice(s).each_col() %= df_s - 2;
    for (int n=0; n<N; n++) {
      forecasts_lambda.slice(s).row(n) /=
        trans(chi2rnd(df_s(n), horizon));
    }
  }
}
```

The `h` loop updates the full row at every step, so each value is scaled more than once.

It should be:

```cpp
for (int s=0; s<S; s++) {
  vec df_s = posterior_df.col(s);
  for (int n=0; n<N; n++) {
    forecasts_lambda.slice(s).row(n) =
      (df_s(n) - 2.0) /
      trans(chi2rnd(df_s(n), horizon));
  }
}
```
