### PR TITLE
Fix Markov-state posterior kernels

### DIFF
--- a/inst/tinytest/test_msh_kernels.R
+++ b/inst/tinytest/test_msh_kernels.R
@@ -147,3 +147,19 @@ expect_identical(
   c(3, 3),
   info = "sample_Markov_process_hmsh: an accepted shock slice is committed independently."
 )
+
+
+# B25 and B26: predecessor uses pi_0 and contributes the initial transition.
+PR_TR <- matrix(c(0.85, 0.15, 0.4, 0.6), 2, 2, byrow = TRUE)
+pi_0 <- c(0.9, 0.1)
+xi <- diag(2)[, c(2, 2, 1, 2, 1), drop = FALSE]
+prior <- list(PR_TR = matrix(1, 2, 2))
+
+set.seed(1)
+probability <- pi_0 * as.numeric(PR_TR %*% xi[, 1])
+predecessor <- .draw_msh_state(probability / sum(probability))
+expect_identical(
+  predecessor,
+  1L,
+  info = "transition fixture distinguishes pi_0-weighted predecessor probabilities."
+)

--- a/inst/tinytest/test_msh_kernels.R
+++ b/inst/tinytest/test_msh_kernels.R
@@ -117,3 +117,33 @@ expect_identical(
   expected_retry$path,
   info = "sample_Markov_process_msh: complete retry path is committed on the final attempt."
 )
+
+
+# B09: accepting one HMSH shock cannot commit another shock's rejected path.
+xi_hmsh <- array(0, c(2, T, 2))
+xi_hmsh[, , 1] <- diag(2)[, rep(1:2, 3), drop = FALSE]
+xi_hmsh[, , 2] <- xi
+PR_TR_hmsh <- array(0, c(2, 2, 2))
+PR_TR_hmsh[, , 1] <- diag(2)
+PR_TR_hmsh[, , 2] <- matrix(c(0, 1, 1, 0), 2, 2, byrow = TRUE)
+
+set.seed(1)
+path_hmsh <- bsvars:::sample_Markov_process_hmsh(
+  xi_hmsh,
+  matrix(0, 2, T),
+  matrix(1, 2, 2),
+  PR_TR_hmsh,
+  matrix(0.5, 2, 2),
+  TRUE
+)
+
+expect_identical(
+  path_hmsh[, , 1],
+  xi_hmsh[, , 1],
+  info = "sample_Markov_process_hmsh: a rejected shock slice remains unchanged."
+)
+expect_identical(
+  as.numeric(rowSums(path_hmsh[, , 2])),
+  c(3, 3),
+  info = "sample_Markov_process_hmsh: an accepted shock slice is committed independently."
+)

--- a/inst/tinytest/test_msh_kernels.R
+++ b/inst/tinytest/test_msh_kernels.R
@@ -158,8 +158,37 @@ prior <- list(PR_TR = matrix(1, 2, 2))
 set.seed(1)
 probability <- pi_0 * as.numeric(PR_TR %*% xi[, 1])
 predecessor <- .draw_msh_state(probability / sum(probability))
+transitions <- bsvars:::count_regime_transitions(xi)
+transitions[predecessor, which.max(xi[, 1])] <-
+  transitions[predecessor, which.max(xi[, 1])] + 1
+posterior_alpha <- transitions + prior$PR_TR
+expected_PR_TR <- rbind(
+  bsvars:::rDirichlet1(posterior_alpha[1, ]),
+  bsvars:::rDirichlet1(posterior_alpha[2, ])
+)
+alpha_0 <- rep(1, 2)
+alpha_0[predecessor] <- alpha_0[predecessor] + 1
+expected_pi_0 <- as.numeric(bsvars:::rDirichlet1(alpha_0))
+
+set.seed(1)
+transition_draw <- bsvars:::sample_transition_probabilities(
+  PR_TR, pi_0, xi, prior, TRUE
+)
+
 expect_identical(
   predecessor,
   1L,
   info = "transition fixture distinguishes pi_0-weighted predecessor probabilities."
+)
+expect_equal(
+  transition_draw$PR_TR,
+  expected_PR_TR,
+  tolerance = 1e-12,
+  info = "sample_transition_probabilities: initial transition augments the correct row and column."
+)
+expect_equal(
+  as.numeric(transition_draw$pi_0),
+  expected_pi_0,
+  tolerance = 1e-12,
+  info = "sample_transition_probabilities: pi_0 is conditioned on the same predecessor draw."
 )

--- a/inst/tinytest/test_msh_kernels.R
+++ b/inst/tinytest/test_msh_kernels.R
@@ -43,3 +43,22 @@ expect_identical(
   path_2,
   info = "sample_Markov_process_msh: FFBS conditions on newly sampled future states."
 )
+
+
+# B07: finite-state acceptance counts observations, not self-transitions.
+T <- 6
+U <- matrix(0, 1, T)
+sigma2 <- matrix(1, 1, 2)
+PR_TR <- matrix(c(0, 1, 1, 0), 2, 2, byrow = TRUE)
+xi <- diag(2)[, rep(1, T), drop = FALSE]
+
+set.seed(1)
+alternating_path <- bsvars:::sample_Markov_process_msh(
+  xi, U, sigma2, PR_TR, pi_0, TRUE
+)
+
+expect_identical(
+  as.numeric(rowSums(alternating_path)),
+  c(3, 3),
+  info = "sample_Markov_process_msh: three non-consecutive observations per regime are accepted."
+)

--- a/inst/tinytest/test_msh_kernels.R
+++ b/inst/tinytest/test_msh_kernels.R
@@ -18,3 +18,28 @@ expect_equal(
   tolerance = 1e-12,
   info = "filtering_msh: log-scale normalization preserves extreme likelihood ratios."
 )
+
+
+# B02: FFBS output does not depend on the placeholder path.
+T <- 8
+U <- matrix(c(-2, -1, 0, 1, 2, 1, 0, -1), 1, T)
+sigma2 <- matrix(c(1, 4), 1, 2)
+PR_TR <- matrix(c(0.9, 0.1, 0.2, 0.8), 2, 2, byrow = TRUE)
+pi_0 <- rep(0.5, 2)
+xi_1 <- diag(2)[, rep(1, T), drop = FALSE]
+xi_2 <- diag(2)[, rep(2, T), drop = FALSE]
+
+set.seed(42)
+path_1 <- bsvars:::sample_Markov_process_msh(
+  xi_1, U, sigma2, PR_TR, pi_0, FALSE
+)
+set.seed(42)
+path_2 <- bsvars:::sample_Markov_process_msh(
+  xi_2, U, sigma2, PR_TR, pi_0, FALSE
+)
+
+expect_identical(
+  path_1,
+  path_2,
+  info = "sample_Markov_process_msh: FFBS conditions on newly sampled future states."
+)

--- a/inst/tinytest/test_msh_kernels.R
+++ b/inst/tinytest/test_msh_kernels.R
@@ -1,3 +1,37 @@
+.draw_msh_state <- function(probability) {
+  .Call(
+    bsvars:::`_bsvars_csample_num1`,
+    seq_along(probability),
+    probability
+  )
+}
+
+.draw_finite_msh_path <- function(xi, U, sigma2, PR_TR, pi_0) {
+  M <- nrow(xi)
+  T <- ncol(xi)
+  filtered <- bsvars:::filtering_msh(U, sigma2, PR_TR, pi_0)
+  smoothed <- bsvars:::smoothing_msh(U, PR_TR, filtered)
+
+  for (iteration in seq_len(10)) {
+    candidate <- matrix(0, M, T)
+    candidate[, T] <- diag(M)[, .draw_msh_state(smoothed[, T])]
+
+    for (t in (T - 1):1) {
+      next_state <- which.max(candidate[, t + 1])
+      probability <- filtered[, t] * PR_TR[, next_state]
+      probability <- probability / sum(probability)
+      candidate[, t] <- diag(M)[, .draw_msh_state(probability)]
+    }
+
+    if (min(rowSums(candidate)) >= 3) {
+      return(list(path = candidate, iteration = iteration))
+    }
+  }
+
+  list(path = xi, iteration = NA_integer_)
+}
+
+
 # B11: filtering preserves likelihood ratios when densities underflow.
 U <- matrix(100, 1, 1)
 sigma2 <- matrix(c(1, 4), 1, 2)
@@ -61,4 +95,25 @@ expect_identical(
   as.numeric(rowSums(alternating_path)),
   c(3, 3),
   info = "sample_Markov_process_msh: three non-consecutive observations per regime are accepted."
+)
+
+
+# B08: every retry redraws the full path and a final-attempt success is kept.
+PR_TR <- matrix(0.5, 2, 2)
+set.seed(45)
+expected_retry <- .draw_finite_msh_path(xi, U, sigma2, PR_TR, pi_0)
+set.seed(45)
+actual_retry <- bsvars:::sample_Markov_process_msh(
+  xi, U, sigma2, PR_TR, pi_0, TRUE
+)
+
+expect_identical(
+  expected_retry$iteration,
+  10L,
+  info = "finite-state fixture succeeds on the final permitted attempt."
+)
+expect_identical(
+  actual_retry,
+  expected_retry$path,
+  info = "sample_Markov_process_msh: complete retry path is committed on the final attempt."
 )

--- a/inst/tinytest/test_msh_kernels.R
+++ b/inst/tinytest/test_msh_kernels.R
@@ -1,0 +1,20 @@
+# B11: filtering preserves likelihood ratios when densities underflow.
+U <- matrix(100, 1, 1)
+sigma2 <- matrix(c(1, 4), 1, 2)
+PR_TR <- diag(2)
+pi_0 <- rep(0.5, 2)
+
+filtered <- bsvars:::filtering_msh(U, sigma2, PR_TR, pi_0)
+log_weight <- c(
+  dnorm(U[1], sd = sqrt(sigma2[1]), log = TRUE),
+  dnorm(U[1], sd = sqrt(sigma2[2]), log = TRUE)
+) + log(pi_0)
+expected <- exp(log_weight - max(log_weight))
+expected <- expected / sum(expected)
+
+expect_equal(
+  as.numeric(filtered[, 1]),
+  expected,
+  tolerance = 1e-12,
+  info = "filtering_msh: log-scale normalization preserves extreme likelihood ratios."
+)

--- a/src/msh.cpp
+++ b/src/msh.cpp
@@ -174,7 +174,7 @@ arma::mat sample_Markov_process_msh (
   
   if ( minimum_regime_occurrences==0 ) {
     for (int t=T-2; t>=0; --t) {
-      vec xi_Tmj    = (aux_PR_TR * (aux_xi.col(t+1)/(aux_PR_TR.t() * filtered.col(t)))) % filtered.col(t);
+      vec xi_Tmj    = (aux_PR_TR * (aux_xi_tmp.col(t+1)/(aux_PR_TR.t() * filtered.col(t)))) % filtered.col(t);
       draw          = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
       aux_xi_tmp.col(t)   = aj.col(draw-1);
     }
@@ -184,7 +184,7 @@ arma::mat sample_Markov_process_msh (
     int iterations  = 1;
     while ( (regime_occurrences<minimum_regime_occurrences) & (iterations<max_iterations) ) {
       for (int t=T-2; t>=0; --t) {
-        vec xi_Tmj    = (aux_PR_TR * (aux_xi.col(t+1)/(aux_PR_TR.t() * filtered.col(t)))) % filtered.col(t);
+        vec xi_Tmj    = (aux_PR_TR * (aux_xi_tmp.col(t+1)/(aux_PR_TR.t() * filtered.col(t)))) % filtered.col(t);
         draw          = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
         aux_xi_tmp.col(t)   = aj.col(draw-1);
       }
@@ -242,7 +242,7 @@ arma::cube sample_Markov_process_hmsh (
     
     if ( minimum_regime_occurrences==0 ) {
       for (int t=T-2; t>=0; --t) {
-        vec xi_Tmj    = (aux_PR_TR.slice(n) * (aux_xi.slice(n).col(t+1)/(aux_PR_TR.slice(n).t() * filtered.col(t)))) % filtered.col(t);
+        vec xi_Tmj    = (aux_PR_TR.slice(n) * (aux_xi_tmp.slice(n).col(t+1)/(aux_PR_TR.slice(n).t() * filtered.col(t)))) % filtered.col(t);
         draw          = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
         aux_xi_tmp.slice(n).col(t)   = aj.col(draw-1);
       }
@@ -252,7 +252,7 @@ arma::cube sample_Markov_process_hmsh (
       int iterations  = 1;
       while ( (regime_occurrences<minimum_regime_occurrences) & (iterations<max_iterations) ) {
         for (int t=T-2; t>=0; --t) {
-          vec xi_Tmj    = (aux_PR_TR.slice(n) * (aux_xi.slice(n).col(t+1)/(aux_PR_TR.slice(n).t() * filtered.col(t)))) % filtered.col(t);
+          vec xi_Tmj    = (aux_PR_TR.slice(n) * (aux_xi_tmp.slice(n).col(t+1)/(aux_PR_TR.slice(n).t() * filtered.col(t)))) % filtered.col(t);
           draw          = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
           aux_xi_tmp.slice(n).col(t)   = aj.col(draw-1);
         } // END t loop

--- a/src/msh.cpp
+++ b/src/msh.cpp
@@ -268,6 +268,7 @@ Rcpp::List sample_transition_probabilities (
     int S0_draw           = csample_num1(wrap(seq_len(M)), wrap(prob_xi1));
 
     mat transitions       = count_regime_transitions(aux_xi);
+    transitions(S0_draw-1, aux_xi.col(0).index_max())++;
     mat posterior_alpha   = transitions + prior_PR_TR;
     
     for (int m=0; m<M; m++) {

--- a/src/msh.cpp
+++ b/src/msh.cpp
@@ -156,7 +156,7 @@ arma::mat sample_Markov_process_msh (
   int minimum_regime_occurrences = 0;
   int max_iterations = 1;
   if ( finiteM ) {
-    minimum_regime_occurrences = 2;
+    minimum_regime_occurrences = 3;
     max_iterations = 10;
   }
   
@@ -188,8 +188,7 @@ arma::mat sample_Markov_process_msh (
         draw          = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
         aux_xi_tmp.col(t)   = aj.col(draw-1);
       }
-      mat transitions       = count_regime_transitions(aux_xi_tmp);
-      regime_occurrences    = min(transitions.diag());
+      regime_occurrences    = min(sum(aux_xi_tmp, 1));
       iterations++;
     } // END while
     if ( iterations<max_iterations ) aux_xi = aux_xi_tmp;
@@ -222,7 +221,7 @@ arma::cube sample_Markov_process_hmsh (
   int minimum_regime_occurrences = 0;
   int max_iterations = 1;
   if ( finiteM ) {
-    minimum_regime_occurrences = 2;
+    minimum_regime_occurrences = 3;
     max_iterations = 10;
   }
   
@@ -257,8 +256,7 @@ arma::cube sample_Markov_process_hmsh (
           aux_xi_tmp.slice(n).col(t)   = aj.col(draw-1);
         } // END t loop
         
-        mat transitions       = count_regime_transitions(aux_xi_tmp.slice(n));
-        regime_occurrences    = min(transitions.diag());
+        regime_occurrences    = min(sum(aux_xi_tmp.slice(n), 1));
         iterations++;
       } // END while
       

--- a/src/msh.cpp
+++ b/src/msh.cpp
@@ -263,15 +263,16 @@ Rcpp::List sample_transition_probabilities (
   const mat   prior_PR_TR = as<mat>(prior["PR_TR"]);
   
   if ( MSnotMIX ) {
+    vec prob_xi1          = aux_pi_0 % (aux_PR_TR * aux_xi.col(0));
+    prob_xi1             /= sum(prob_xi1);
+    int S0_draw           = csample_num1(wrap(seq_len(M)), wrap(prob_xi1));
+
     mat transitions       = count_regime_transitions(aux_xi);
     mat posterior_alpha   = transitions + prior_PR_TR;
     
     for (int m=0; m<M; m++) {
       aux_PR_TR.row(m)    = rDirichlet1(posterior_alpha.row(m));
     }
-    vec prob_xi1          = aux_PR_TR *aux_xi.col(0);
-    prob_xi1             /= sum(prob_xi1);
-    int S0_draw           = csample_num1(wrap(seq_len(M)), wrap(prob_xi1));
     rowvec posterior_alpha_0(M, fill::value((1.0)));
     posterior_alpha_0(S0_draw-1)++;
     aux_pi_0              = trans(rDirichlet1(posterior_alpha_0));

--- a/src/msh.cpp
+++ b/src/msh.cpp
@@ -209,7 +209,6 @@ arma::cube sample_Markov_process_hmsh (
   const int   T   = U.n_cols;
   const int   N   = U.n_rows;
   const int   M   = aux_PR_TR.n_cols;
-  cube aux_xi_tmp = aux_xi;
   mat     aj      = eye(M, M);
   
   for (int n=0; n<N; n++) {
@@ -217,17 +216,18 @@ arma::cube sample_Markov_process_hmsh (
     mat smoothed    = smoothing_msh(U.row(n), aux_PR_TR.slice(n), filtered);
 
     for (int iteration=0; iteration<max_iterations; iteration++) {
+      mat aux_xi_tmp(M, T);
       int draw = csample_num1(wrap(seq_len(M)), wrap(smoothed.col(T-1)));
-      aux_xi_tmp.slice(n).col(T-1) = aj.col(draw-1);
+      aux_xi_tmp.col(T-1) = aj.col(draw-1);
 
       for (int t=T-2; t>=0; --t) {
-        vec xi_Tmj = (aux_PR_TR.slice(n) * (aux_xi_tmp.slice(n).col(t+1)/(aux_PR_TR.slice(n).t() * filtered.col(t)))) % filtered.col(t);
+        vec xi_Tmj = (aux_PR_TR.slice(n) * (aux_xi_tmp.col(t+1)/(aux_PR_TR.slice(n).t() * filtered.col(t)))) % filtered.col(t);
         draw = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
-        aux_xi_tmp.slice(n).col(t) = aj.col(draw-1);
+        aux_xi_tmp.col(t) = aj.col(draw-1);
       }
 
-      if (!finiteM || min(sum(aux_xi_tmp.slice(n), 1)) >= minimum_regime_occurrences) {
-        aux_xi = aux_xi_tmp;
+      if (!finiteM || min(sum(aux_xi_tmp, 1)) >= minimum_regime_occurrences) {
+        aux_xi.slice(n) = aux_xi_tmp;
         break;
       }
     }

--- a/src/msh.cpp
+++ b/src/msh.cpp
@@ -153,45 +153,30 @@ arma::mat sample_Markov_process_msh (
 ) {
   // the function changes the value of aux_xi by reference (filling it with a new draw)
   
-  int minimum_regime_occurrences = 0;
-  int max_iterations = 1;
-  if ( finiteM ) {
-    minimum_regime_occurrences = 3;
-    max_iterations = 10;
-  }
+  const int minimum_regime_occurrences = finiteM ? 3 : 0;
+  const int max_iterations = finiteM ? 10 : 1;
   
   const int   T   = U.n_cols;
   const int   M   = aux_PR_TR.n_rows;
-  mat aux_xi_tmp  = aux_xi;
-  
   mat filtered    = filtering_msh(U, aux_sigma2, aux_PR_TR, aux_pi_0);
   mat smoothed    = smoothing_msh(U, aux_PR_TR, filtered);
   mat     aj      = eye(M, M);
   
-  mat xi(M, T);
-  int draw        = csample_num1(wrap(seq_len(M)), wrap(smoothed.col(T-1)));
-  aux_xi_tmp.col(T-1)     = aj.col(draw-1);
-  
-  if ( minimum_regime_occurrences==0 ) {
+  for (int iteration=0; iteration<max_iterations; iteration++) {
+    mat aux_xi_tmp(M, T);
+    int draw = csample_num1(wrap(seq_len(M)), wrap(smoothed.col(T-1)));
+    aux_xi_tmp.col(T-1) = aj.col(draw-1);
+
     for (int t=T-2; t>=0; --t) {
-      vec xi_Tmj    = (aux_PR_TR * (aux_xi_tmp.col(t+1)/(aux_PR_TR.t() * filtered.col(t)))) % filtered.col(t);
-      draw          = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
-      aux_xi_tmp.col(t)   = aj.col(draw-1);
+      vec xi_Tmj = (aux_PR_TR * (aux_xi_tmp.col(t+1)/(aux_PR_TR.t() * filtered.col(t)))) % filtered.col(t);
+      draw = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
+      aux_xi_tmp.col(t) = aj.col(draw-1);
     }
-    aux_xi = aux_xi_tmp;
-  } else {
-    int regime_occurrences  = 1;
-    int iterations  = 1;
-    while ( (regime_occurrences<minimum_regime_occurrences) & (iterations<max_iterations) ) {
-      for (int t=T-2; t>=0; --t) {
-        vec xi_Tmj    = (aux_PR_TR * (aux_xi_tmp.col(t+1)/(aux_PR_TR.t() * filtered.col(t)))) % filtered.col(t);
-        draw          = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
-        aux_xi_tmp.col(t)   = aj.col(draw-1);
-      }
-      regime_occurrences    = min(sum(aux_xi_tmp, 1));
-      iterations++;
-    } // END while
-    if ( iterations<max_iterations ) aux_xi = aux_xi_tmp;
+
+    if (!finiteM || min(sum(aux_xi_tmp, 1)) >= minimum_regime_occurrences) {
+      aux_xi = aux_xi_tmp;
+      break;
+    }
   }
   
   return aux_xi;
@@ -218,50 +203,34 @@ arma::cube sample_Markov_process_hmsh (
     const bool        finiteM = true
 ) {
   
-  int minimum_regime_occurrences = 0;
-  int max_iterations = 1;
-  if ( finiteM ) {
-    minimum_regime_occurrences = 3;
-    max_iterations = 10;
-  }
+  const int minimum_regime_occurrences = finiteM ? 3 : 0;
+  const int max_iterations = finiteM ? 10 : 1;
   
   const int   T   = U.n_cols;
   const int   N   = U.n_rows;
   const int   M   = aux_PR_TR.n_cols;
   cube aux_xi_tmp = aux_xi;
-  mat xi(M, T);
-  
   mat     aj      = eye(M, M);
   
   for (int n=0; n<N; n++) {
     mat filtered    = filtering_msh(U.row(n), aux_sigma2.row(n), aux_PR_TR.slice(n), aux_pi_0.col(n));
     mat smoothed    = smoothing_msh(U.row(n), aux_PR_TR.slice(n), filtered);
-    int draw        = csample_num1(wrap(seq_len(M)), wrap(smoothed.col(T-1)));
-    aux_xi_tmp.slice(n).col(T-1)     = aj.col(draw-1);
-    
-    if ( minimum_regime_occurrences==0 ) {
+
+    for (int iteration=0; iteration<max_iterations; iteration++) {
+      int draw = csample_num1(wrap(seq_len(M)), wrap(smoothed.col(T-1)));
+      aux_xi_tmp.slice(n).col(T-1) = aj.col(draw-1);
+
       for (int t=T-2; t>=0; --t) {
-        vec xi_Tmj    = (aux_PR_TR.slice(n) * (aux_xi_tmp.slice(n).col(t+1)/(aux_PR_TR.slice(n).t() * filtered.col(t)))) % filtered.col(t);
-        draw          = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
-        aux_xi_tmp.slice(n).col(t)   = aj.col(draw-1);
+        vec xi_Tmj = (aux_PR_TR.slice(n) * (aux_xi_tmp.slice(n).col(t+1)/(aux_PR_TR.slice(n).t() * filtered.col(t)))) % filtered.col(t);
+        draw = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
+        aux_xi_tmp.slice(n).col(t) = aj.col(draw-1);
       }
-      aux_xi = aux_xi_tmp;
-    } else {
-      int regime_occurrences  = 1;
-      int iterations  = 1;
-      while ( (regime_occurrences<minimum_regime_occurrences) & (iterations<max_iterations) ) {
-        for (int t=T-2; t>=0; --t) {
-          vec xi_Tmj    = (aux_PR_TR.slice(n) * (aux_xi_tmp.slice(n).col(t+1)/(aux_PR_TR.slice(n).t() * filtered.col(t)))) % filtered.col(t);
-          draw          = csample_num1(wrap(seq_len(M)), wrap(xi_Tmj));
-          aux_xi_tmp.slice(n).col(t)   = aj.col(draw-1);
-        } // END t loop
-        
-        regime_occurrences    = min(sum(aux_xi_tmp.slice(n), 1));
-        iterations++;
-      } // END while
-      
-      if ( iterations<max_iterations ) aux_xi = aux_xi_tmp;
-    } // END if else
+
+      if (!finiteM || min(sum(aux_xi_tmp.slice(n), 1)) >= minimum_regime_occurrences) {
+        aux_xi = aux_xi_tmp;
+        break;
+      }
+    }
   } // END n loop
   
   return aux_xi;

--- a/src/msh.cpp
+++ b/src/msh.cpp
@@ -87,24 +87,23 @@ arma::mat filtering_msh (
   const int   N = U.n_rows;
   const int   M = PR_TR.n_rows;
   
-  mat         eta_t(M, T);
+  mat         log_eta_t(M, T);
   mat         xi_t_t(M, T);
   
   // This loop evaluates mvnormal pdf at U - simplified operations for zero-mean diagonal-covariance case
   for (int m=0; m<M; m++) {
     rowvec log_d    = -0.5 * sum(pow( pow(sigma.col(m), -0.5) % U.each_col(), 2), 0);
     log_d          += -0.5 * N * log(2*M_PI) - 0.5 * log(prod(sigma.col(m)));
-    NumericVector   exp_log_d   = wrap(exp(log_d));
-    exp_log_d[exp_log_d==0]     = 1e-300;
-    eta_t.row(m)    = as<rowvec>(exp_log_d);
+    log_eta_t.row(m) = log_d;
   } // END m loop
   
   vec xi_tm1_tm1    = pi_0;
   
   for (int t=0; t<T; t++) {
-    vec     num     = eta_t.col(t) % (PR_TR.t() * xi_tm1_tm1);
-    double  den     = sum(num);
-    xi_t_t.col(t)   = num/den;
+    vec log_weight  = log_eta_t.col(t) + log(PR_TR.t() * xi_tm1_tm1);
+    log_weight     -= max(log_weight);
+    vec weight      = exp(log_weight);
+    xi_t_t.col(t)   = weight / sum(weight);
     xi_tm1_tm1      = xi_t_t.col(t);
   } // END t loop
 
@@ -393,4 +392,3 @@ arma::mat sample_variances_hmsh (
   
   return aux_sigma2;
 } // END sample_variances_hmsh
-


### PR DESCRIPTION
Findings:
- **B02:** Condition FFBS backward draws on the newly sampled future state.
- **B07:** Align finite-regime acceptance with the stated bsvar_hmsh requirement by counting all observations assigned to each regime and requiring at least three, instead of counting only consecutive same-regime transitions.
- **B08:** Resample the terminal state `s_T` (shock-specific `s_{n.T}` in HMSH) on every retry and redraw the full FFBS path, because holding the terminal state fixed makes retries conditional on the first rejected terminal state rather than fresh full-path posterior draws; also preserve a valid candidate accepted on the final permitted attempt.
- **B09: Prevent an accepted HMSH path from saving other shocks’ rejected paths.**  
  When one shock’s candidate path was accepted, the sampler copied the entire \(M\times T\times N\) state cube, which could also save another shock’s rejected candidate path. Store each candidate in a separate \(M\times T\) matrix and update only `aux_xi.slice(n)` after it passes the acceptance check.
- **B11:** Use the log-sum-exp trick to normalize filtering weights in log space, preventing numerical underflow from collapsing distinct likelihoods and preserving their relative ratios.
- **B25:** Include pi_0 when drawing the pre-sample state.
- **B26:** Include the transition from the sampled pre-sample regime \(s_{n.0}\) to the first in-sample regime \(s_{n.1}\) when updating the posterior distribution of the transition matrix \(\mathbf P_n\).

**Regression test:** `test_msh_kernels.R` verifies deterministic outcomes for filtering, FFBS backward sampling, retry handling, shock isolation, and transition draws.
Audit: [PDF](https://mega.nz/file/KTgDGJxQ#N400LNNFnYz0Q14CjD4v-S1MGJ6OKYMLKymxvZjBN7Y)