### PR TITLE
Correct MSH state-likelihood inputs

### DIFF
--- a/inst/tinytest/test_msh_driver_inputs.R
+++ b/inst/tinytest/test_msh_driver_inputs.R
@@ -1,0 +1,79 @@
+data(us_fiscal_lsuw)
+
+forced_transition = matrix(
+  c(1e-12, 1 - 1e-12, 1e-12, 1 - 1e-12),
+  2,
+  2,
+  byrow = TRUE
+)
+
+msh = suppressMessages(specify_bsvar_msh$new(us_fiscal_lsuw, M = 2))
+msh_start = msh$starting_values$get_starting_values()
+msh_start$PR_TR = forced_transition
+msh_start$pi_0 = c(0.5, 0.5)
+msh_start$sigma2[, 1] = 1e-12
+msh_start$sigma2[, 2] = 1
+msh_start$xi = rbind(
+  rep(1, ncol(msh_start$xi)),
+  rep(0, ncol(msh_start$xi))
+)
+msh_data = msh$data_matrices$get_data_matrices()
+
+set.seed(171)
+msh_draw = .Call(
+  "_bsvars_bsvar_msh_cpp",
+  1L,
+  msh_data$Y,
+  msh_data$X,
+  msh$prior$get_prior(),
+  msh$identification$VB,
+  msh$identification$VA,
+  msh_start,
+  TRUE,
+  1L,
+  FALSE,
+  TRUE,
+  "test",
+  FALSE,
+  PACKAGE = "bsvars"
+)
+
+expect_true(
+  all(msh_draw$posterior$xi[2, , 1] == 1),
+  info = "The MSH driver passes structural residuals, not an empty or volatility-standardised matrix, to the first state draw."
+)
+
+hmsh = suppressMessages(specify_bsvar_hmsh$new(us_fiscal_lsuw, M = 2))
+hmsh_start = hmsh$starting_values$get_starting_values()
+hmsh_start$PR_TR = array(0, c(2, 2, 3))
+for (n in 1:3) hmsh_start$PR_TR[, , n] = forced_transition
+hmsh_start$pi_0 = matrix(0.5, 2, 3)
+hmsh_start$sigma2[, 1] = 1e-12
+hmsh_start$sigma2[, 2] = 1
+hmsh_start$xi = array(0, dim(hmsh_start$xi))
+hmsh_start$xi[1, , ] = 1
+hmsh_data = hmsh$data_matrices$get_data_matrices()
+
+set.seed(172)
+hmsh_draw = .Call(
+  "_bsvars_bsvar_hmsh_cpp",
+  1L,
+  hmsh_data$Y,
+  hmsh_data$X,
+  hmsh$prior$get_prior(),
+  hmsh$identification$VB,
+  hmsh$identification$VA,
+  hmsh_start,
+  TRUE,
+  1L,
+  FALSE,
+  TRUE,
+  "test",
+  FALSE,
+  PACKAGE = "bsvars"
+)
+
+expect_true(
+  all(hmsh_draw$posterior$xi_cpp[[1]][2, , ] == 1),
+  info = "The HMSH driver passes structural residuals, not an empty or volatility-standardised matrix, to the first state draw."
+)

--- a/src/bsvar_hmsh.cpp
+++ b/src/bsvar_hmsh.cpp
@@ -122,8 +122,8 @@ Rcpp::List bsvar_hmsh_cpp (
       } catch (std::runtime_error &e) {}
     }
     
-      
     // sample aux_xi
+    U                 = aux_B * (Y - aux_A * X) / aux_lambda_sqrt;
     try {
       aux_xi            = sample_Markov_process_hmsh(aux_xi, U, aux_sigma2, aux_PR_TR, aux_pi_0, finiteM);
     } catch (std::runtime_error &e) {}

--- a/src/bsvar_msh.cpp
+++ b/src/bsvar_msh.cpp
@@ -120,7 +120,7 @@ Rcpp::List bsvar_msh_cpp (
     }
     
     // sample aux_xi
-    U                 = aux_B * (Y - aux_A * X) / aux_sigma;
+    U                 = aux_B * (Y - aux_A * X) / aux_lambda_sqrt;
     try {
       aux_xi            = sample_Markov_process_msh(aux_xi, U, aux_sigma2, aux_PR_TR, aux_pi_0, finiteM);
     } catch (std::runtime_error &e) {}


### PR DESCRIPTION
## Problem

The MSH/HMSH state sampler should evaluate each candidate regime using the structural residuals

`u_t = B_0 (y_t - A x_t)`

after removing only the Student-t latent scale `sqrt(lambda_t)`. In the MSH driver, the residuals were instead divided by the volatility selected by the currently stored state path before filtering. The filter then divided them by each candidate regime volatility again, so the new state likelihood incorrectly depended on the old state path. In Student-t runs, the same input also failed to remove `sqrt(lambda_t)`.

In the normal HMSH driver, `U` was assigned only inside `if (!normal)` before the first state update. The first normal-model state draw therefore received an empty residual matrix; the caught failure left the starting state path unchanged for that sweep.

## Fix

Immediately before state sampling, both drivers now construct

```cpp
U = aux_B * (Y - aux_A * X) / aux_lambda_sqrt;
```

For a normal model, `aux_lambda_sqrt` is an all-ones matrix, so `U` is the unscaled structural residual matrix. For a Student-t model, this removes `sqrt(lambda_t)` while leaving the candidate regime variances for the state filter to evaluate. In HMSH, placing the assignment outside `if (!normal)` also guarantees that `U` is initialized before every state update.

## Findings

- **B01:** Pass structural residuals scaled only by `sqrt(lambda)` into the MSH state likelihood.
- **B06:** Initialize the HMSH state-kernel residual matrix before the first normal-model sweep.

## Verification

`test_msh_driver_inputs.R` forces deterministic first-state draws in both drivers. It fails if the MSH state likelihood receives residuals divided by the currently stored regime volatility, or if the first normal-HMSH state update receives an empty or incorrectly scaled residual matrix.

## Audit

[Commit-scoped audit PDF](https://mega.nz/file/HeJi3RDQ#gKR_1SDqWxi7qnjGwZRY0YsL4RrbTvKTl_aPh2-VB8E)