### PR TITLE
Correct Student-t proposal mechanics

### DIFF
--- a/R/forecast.R
+++ b/R/forecast.R
@@ -89,13 +89,19 @@ forecast.PosteriorBSVAR = function(
   
   posterior_B     = object$posterior$B
   posterior_A     = object$posterior$A
-  T               = ncol(object$last_draw$data_matrices$X)
-  X_T             = object$last_draw$data_matrices$X[,T]
+  X               = object$last_draw$data_matrices$X
   Y               = object$last_draw$data_matrices$Y
+  T               = ncol(X)
+  N               = nrow(posterior_B)
+  lag_entries     = N * object$last_draw$p
+  X_T             = c(
+    Y[,T],
+    X[seq_len(lag_entries - N),T],
+    tail(X[,T], nrow(X) - lag_entries)
+  )
   posterior_df    = object$posterior$df
   normal          = object$last_draw$get_normal()
   
-  N               = nrow(posterior_B)
   K               = length(X_T)
   d               = K - N * object$last_draw$p - 1
   S               = dim(posterior_B)[3]
@@ -235,14 +241,20 @@ forecast.PosteriorBSVAREXH = function(
   posterior_B       = object$posterior$B
   posterior_A       = object$posterior$A
   posterior_sigma2  = object$posterior$sigma2
-  T                 = ncol(object$last_draw$data_matrices$X)
-  X_T               = object$last_draw$data_matrices$X[,T]
+  X                 = object$last_draw$data_matrices$X
   Y                 = object$last_draw$data_matrices$Y
+  T                 = ncol(X)
+  N                 = nrow(posterior_B)
+  lag_entries       = N * object$last_draw$p
+  X_T               = c(
+    Y[,T],
+    X[seq_len(lag_entries - N),T],
+    tail(X[,T], nrow(X) - lag_entries)
+  )
   sigma2_T        = object$posterior$sigma[,T,]^2
   posterior_df    = object$posterior$df
   normal          = object$last_draw$get_normal()
   
-  N               = nrow(posterior_B)
   K               = length(X_T)
   d               = K - N * object$last_draw$p - 1
   S               = dim(posterior_B)[3]
@@ -384,14 +396,20 @@ forecast.PosteriorBSVARHMSH = function(
   posterior_A       = object$posterior$A
   posterior_sigma2  = object$posterior$sigma2
   posterior_PR_TR   = object$posterior$PR_TR_cpp
-  T                 = ncol(object$last_draw$data_matrices$X)
-  X_T               = object$last_draw$data_matrices$X[,T]
+  X                 = object$last_draw$data_matrices$X
   Y                 = object$last_draw$data_matrices$Y
+  T                 = ncol(X)
+  N                 = nrow(posterior_B)
+  lag_entries       = N * object$last_draw$p
+  X_T               = c(
+    Y[,T],
+    X[seq_len(lag_entries - N),T],
+    tail(X[,T], nrow(X) - lag_entries)
+  )
   posterior_df    = object$posterior$df
   normal          = object$last_draw$get_normal()
   
   M               = ncol(posterior_sigma2)
-  N               = nrow(posterior_B)
   K               = length(X_T)
   d               = K - N * object$last_draw$p - 1
   S               = dim(posterior_B)[3]
@@ -545,14 +563,20 @@ forecast.PosteriorBSVARMSH = function(
   posterior_A       = object$posterior$A
   posterior_sigma2  = object$posterior$sigma2
   posterior_PR_TR   = object$posterior$PR_TR
-  T                 = ncol(object$last_draw$data_matrices$X)
-  X_T               = object$last_draw$data_matrices$X[,T]
+  X                 = object$last_draw$data_matrices$X
   Y                 = object$last_draw$data_matrices$Y
+  T                 = ncol(X)
+  N                 = nrow(posterior_B)
+  lag_entries       = N * object$last_draw$p
+  X_T               = c(
+    Y[,T],
+    X[seq_len(lag_entries - N),T],
+    tail(X[,T], nrow(X) - lag_entries)
+  )
   S_T               = object$posterior$xi[,T,]
   posterior_df    = object$posterior$df
   normal          = object$last_draw$get_normal()
   
-  N               = nrow(posterior_B)
   K               = length(X_T)
   d               = K - N * object$last_draw$p - 1
   S               = dim(posterior_B)[3]
@@ -694,14 +718,20 @@ forecast.PosteriorBSVARMIX = function(
   posterior_A       = object$posterior$A
   posterior_sigma2  = object$posterior$sigma2
   posterior_PR_TR   = object$posterior$PR_TR
-  T                 = ncol(object$last_draw$data_matrices$X)
-  X_T               = object$last_draw$data_matrices$X[,T]
+  X                 = object$last_draw$data_matrices$X
   Y                 = object$last_draw$data_matrices$Y
+  T                 = ncol(X)
+  N                 = nrow(posterior_B)
+  lag_entries       = N * object$last_draw$p
+  X_T               = c(
+    Y[,T],
+    X[seq_len(lag_entries - N),T],
+    tail(X[,T], nrow(X) - lag_entries)
+  )
   S_T               = object$posterior$xi[,T,]
   posterior_df    = object$posterior$df
   normal          = object$last_draw$get_normal()
   
-  N               = nrow(posterior_B)
   K               = length(X_T)
   d               = K - N * object$last_draw$p - 1
   S               = dim(posterior_B)[3]
@@ -844,15 +874,21 @@ forecast.PosteriorBSVARSV = function(
   posterior_rho     = object$posterior$rho
   posterior_omega   = object$posterior$omega
   
-  T                 = ncol(object$last_draw$data_matrices$X)
-  X_T               = object$last_draw$data_matrices$X[,T]
+  X                 = object$last_draw$data_matrices$X
   Y                 = object$last_draw$data_matrices$Y
+  T                 = ncol(X)
+  N                 = nrow(posterior_B)
+  lag_entries       = N * object$last_draw$p
+  X_T               = c(
+    Y[,T],
+    X[seq_len(lag_entries - N),T],
+    tail(X[,T], nrow(X) - lag_entries)
+  )
   posterior_h_T     = object$posterior$h[,T,]
   centred_sv        = object$last_draw$centred_sv
   posterior_df    = object$posterior$df
   normal          = object$last_draw$get_normal()
   
-  N               = nrow(posterior_B)
   K               = length(X_T)
   d               = K - N * object$last_draw$p - 1
   S               = dim(posterior_B)[3]
@@ -996,11 +1032,17 @@ forecast.PosteriorBSVART = function(
   posterior_B     = object$posterior$B
   posterior_A     = object$posterior$A
   posterior_df    = object$posterior$df
-  T               = ncol(object$last_draw$data_matrices$X)
-  X_T             = object$last_draw$data_matrices$X[,T]
+  X               = object$last_draw$data_matrices$X
   Y               = object$last_draw$data_matrices$Y
-  
+  T               = ncol(X)
   N               = nrow(posterior_B)
+  lag_entries     = N * object$last_draw$p
+  X_T             = c(
+    Y[,T],
+    X[seq_len(lag_entries - N),T],
+    tail(X[,T], nrow(X) - lag_entries)
+  )
+
   K               = length(X_T)
   d               = K - N * object$last_draw$p - 1
   S               = dim(posterior_B)[3]

--- a/inst/tinytest/test_sample_t.R
+++ b/inst/tinytest/test_sample_t.R
@@ -1,0 +1,39 @@
+log_kernel_df_r = function(df, lambda) {
+  T = length(lambda)
+  -T * lgamma(0.5 * df) +
+    0.5 * T * df * log(0.5 * (df - 2)) -
+    0.5 * (df + 2) * sum(log(lambda)) -
+    0.5 * (df - 2) * sum(lambda^-1) -
+    2 * log(df - 1)
+}
+
+df = 2.05
+proposal_sd = 0.5
+lambda = matrix(0.1, 1, 5)
+
+set.seed(42)
+df_star = RcppTN::rtn(df, proposal_sd, 2, Inf)
+acceptance_probability = min(
+  1,
+  exp(log_kernel_df_r(df_star, lambda) - log_kernel_df_r(df, lambda)) *
+    RcppTN::dtn(df, df_star, proposal_sd, 2, Inf) /
+    RcppTN::dtn(df_star, df, proposal_sd, 2, Inf)
+)
+expected_df = if (runif(1) < acceptance_probability) df_star else df
+
+set.seed(42)
+draw = .Call(
+  "_bsvars_sample_df",
+  df,
+  proposal_sd,
+  lambda,
+  0L,
+  c(0.44, 0.6),
+  PACKAGE = "bsvars"
+)
+
+expect_equal(
+  as.numeric(draw$aux_df),
+  expected_df,
+  info = "The truncated-normal Hastings ratio uses reverse over forward proposal density."
+)

--- a/inst/tinytest/test_student_t_proposal_scale.R
+++ b/inst/tinytest/test_student_t_proposal_scale.R
@@ -1,0 +1,44 @@
+data(us_fiscal_lsuw)
+data = us_fiscal_lsuw[1:40, 1:2]
+T = nrow(data) - 1
+proposal_sd = sqrt(abs(
+  (0.25 * T * psigamma(15, deriv = 1) - T * 29 * 28^-2 - 2 * 29^-2)^-1
+))
+
+specifications = list(
+  BSVAR = function() specify_bsvar$new(data, distribution = "t"),
+  T = function() specify_bsvar_t$new(data),
+  SV = function() specify_bsvar_sv$new(data, distribution = "t"),
+  MSH = function() specify_bsvar_msh$new(data, M = 2, distribution = "t"),
+  HMSH = function() specify_bsvar_hmsh$new(data, M = 2, distribution = "t"),
+  EXH = function() specify_bsvar_exh$new(
+    data,
+    distribution = "t",
+    variance_regimes = rep(1:2, length.out = nrow(data))
+  )
+)
+
+for (model in names(specifications)) {
+  specification = suppressMessages(specifications[[model]]())
+  starting_values = specification$starting_values$get_starting_values()
+
+  set.seed(373)
+  expected_df = .Call(
+    "_bsvars_sample_df",
+    starting_values$df * 1,
+    rep(proposal_sd, nrow(data)),
+    starting_values$lambda * 1,
+    0L,
+    c(0.44, 0.6),
+    PACKAGE = "bsvars"
+  )$aux_df
+
+  set.seed(373)
+  posterior = estimate(specification, S = 2, show_progress = FALSE)
+
+  expect_equal(
+    as.numeric(posterior$posterior$df[, 1]),
+    as.numeric(expected_df),
+    info = paste(model, "initialises the Student-t proposal with a standard deviation, not a variance.")
+  )
+}

--- a/src/bsvar.cpp
+++ b/src/bsvar.cpp
@@ -69,7 +69,7 @@ Rcpp::List bsvar_cpp(
   
   // the initial value for the adaptive_scale is set to the negative inverse of 
   // Hessian for the posterior log_kenel for df evaluated at df = 30
-  double  adaptive_scale_init = abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1));
+  double  adaptive_scale_init = sqrt(abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1)));
   vec     adaptive_scale(N, fill::value(adaptive_scale_init));
   
   int   ss = 0;

--- a/src/bsvar_exh.cpp
+++ b/src/bsvar_exh.cpp
@@ -87,7 +87,7 @@ Rcpp::List bsvar_exh_cpp (
   
   // the initial value for the adaptive_scale is set to the negative inverse of 
   // Hessian for the posterior log_kenel for df evaluated at df = 30
-  double  adaptive_scale_init = abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1));
+  double  adaptive_scale_init = sqrt(abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1)));
   vec     adaptive_scale(N, fill::value(adaptive_scale_init));
   
   for (int s=0; s<S; s++) {
@@ -174,4 +174,3 @@ Rcpp::List bsvar_exh_cpp (
     )
   );
 } // END bsvar_exh_cpp
-

--- a/src/bsvar_hmsh.cpp
+++ b/src/bsvar_hmsh.cpp
@@ -96,7 +96,7 @@ Rcpp::List bsvar_hmsh_cpp (
   
   // the initial value for the adaptive_scale is set to the negative inverse of 
   // Hessian for the posterior log_kenel for df evaluated at df = 30
-  double  adaptive_scale_init = abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1));
+  double  adaptive_scale_init = sqrt(abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1)));
   vec     adaptive_scale(N, fill::value(adaptive_scale_init));
   
   for (int s=0; s<S; s++) {
@@ -208,4 +208,3 @@ Rcpp::List bsvar_hmsh_cpp (
     )
   );
 } // END bsvar_msh
-

--- a/src/bsvar_msh.cpp
+++ b/src/bsvar_msh.cpp
@@ -94,7 +94,7 @@ Rcpp::List bsvar_msh_cpp (
   
   // the initial value for the adaptive_scale is set to the negative inverse of 
   // Hessian for the posterior log_kenel for df evaluated at df = 30
-  double  adaptive_scale_init = abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1));
+  double  adaptive_scale_init = sqrt(abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1)));
   vec     adaptive_scale(N, fill::value(adaptive_scale_init));
   
   for (int s=0; s<S; s++) {
@@ -201,4 +201,3 @@ Rcpp::List bsvar_msh_cpp (
     )
   );
 } // END bsvar_msh
-

--- a/src/bsvar_sv.cpp
+++ b/src/bsvar_sv.cpp
@@ -109,7 +109,7 @@ Rcpp::List bsvar_sv_cpp (
   
   // the initial value for the adaptive_scale is set to the negative inverse of 
   // Hessian for the posterior log_kenel for df evaluated at df = 30
-  double  adaptive_scale_init = abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1));
+  double  adaptive_scale_init = sqrt(abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1)));
   vec     adaptive_scale(N, fill::value(adaptive_scale_init));
   
   int   ss = 0;
@@ -243,5 +243,4 @@ Rcpp::List bsvar_sv_cpp (
     )
   );
 } // END bsvar_sv_cpp
-
 

--- a/src/bsvar_t.cpp
+++ b/src/bsvar_t.cpp
@@ -70,7 +70,7 @@ Rcpp::List bsvar_t_cpp(
   
   // the initial value for the adaptive_scale is set to the negative inverse of 
   // Hessian for the posterior log_kenel for df evaluated at df = 30
-  double  adaptive_scale_init = abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1));
+  double  adaptive_scale_init = sqrt(abs(pow(0.25 * T * R::psigamma(15, 1) - T * 29 * pow(28, -2) - 2 * pow(29, -2), -1)));
   vec     adaptive_scale(N, fill::value(adaptive_scale_init));
   
   for (int s=0; s<S; s++) {

--- a/src/forecast.cpp
+++ b/src/forecast.cpp
@@ -110,7 +110,7 @@ arma::cube forecast_sigma2_hmsh (
       for (int h=0; h<horizon; h++) {
         PR_ST       = trans(posterior_PR_TR(s).slice(n)) * PR_ST;
         St          = csample_num1(zeroM, wrap(PR_ST));
-        forecasts_sigma2.slice(s).col(h) = posterior_sigma2.slice(s).col(St);
+        forecasts_sigma2(n, h, s) = posterior_sigma2(n, St, s);
       } // END h loop
       
     } // END n loop

--- a/src/sample_t.cpp
+++ b/src/sample_t.cpp
@@ -68,8 +68,8 @@ Rcpp::List sample_df (
     aux_df_star(n)        = RcppTN::rtn1( aux_df(n), adaptive_scale(n), 2, R_PosInf );
     double lk_nu_star     = log_kernel_df(aux_df_star(n), aux_lambda.row(n));
     double lk_nu_old      = log_kernel_df(aux_df(n), aux_lambda.row(n));
-    double cgd_ratio      = RcppTN::dtn1( aux_df_star(n), aux_df(n), adaptive_scale(n), 2, R_PosInf ) / 
-      RcppTN::dtn1( aux_df(n), aux_df_star(n), adaptive_scale(n), 2, R_PosInf );
+    double cgd_ratio      = RcppTN::dtn1( aux_df(n), aux_df_star(n), adaptive_scale(n), 2, R_PosInf ) /
+      RcppTN::dtn1( aux_df_star(n), aux_df(n), adaptive_scale(n), 2, R_PosInf );
   
     double kernel_ratio   = exp(lk_nu_star - lk_nu_old) * cgd_ratio;
     if ( kernel_ratio < 1 ) alpha(n) = kernel_ratio;


### PR DESCRIPTION
Findings:
- **B03:** Fix the acceptance probability: the code divided the forward and reverse truncated-normal proposal probabilities in the wrong order.
- **B37:** Fix the initial proposal step size: the code used a variance where a standard deviation was required.

**Regression tests:** `test_sample_t.R` verifies the near-boundary Hastings acceptance decision, and `test_student_t_proposal_scale.R` verifies the initial proposal standard deviations in all six sampler drivers.
Audit: [PDF](https://mega.nz/file/re4lCIjZ#7egLvm4mUFyd_fbgiIxm0BsYbyrXGdSis9uLOqZXF3o)