### PR TITLE
Align HMSH state output with retained draws

### DIFF
--- a/R/estimate.BSVARHMSH.R
+++ b/R/estimate.BSVARHMSH.R
@@ -128,9 +128,9 @@ estimate.BSVARHMSH <- function(specification, S, thin = 1, show_progress = TRUE)
   output              = specify_posterior_bsvar_hmsh$new(specification, qqq$posterior)
   
   # reshape some of the outputs
-  PR_TR               = array(NA, c(dim(starting_values$PR_TR), S))
-  xi                  = array(NA, c(dim(starting_values$xi), S))
   SS                  = dim(qqq$posterior$PR_TR)[1]
+  PR_TR               = array(NA, c(dim(starting_values$PR_TR), SS))
+  xi                  = array(NA, c(dim(starting_values$xi), SS))
   for (s in 1:SS) {
     PR_TR[,,,s]       = qqq$posterior$PR_TR[s,1][[1]]
     xi[,,,s]          = qqq$posterior$xi[s,1][[1]]
@@ -194,9 +194,10 @@ estimate.PosteriorBSVARHMSH <- function(specification, S, thin = 1, show_progres
   output              = specify_posterior_bsvar_hmsh$new(specification$last_draw, qqq$posterior)
   
   # reshape some of the outputs
-  PR_TR               = array(NA, c(dim(starting_values$PR_TR), S))
-  xi                  = array(NA, c(dim(starting_values$xi), S))
-  for (s in 1:S) {
+  SS                  = dim(qqq$posterior$PR_TR)[1]
+  PR_TR               = array(NA, c(dim(starting_values$PR_TR), SS))
+  xi                  = array(NA, c(dim(starting_values$xi), SS))
+  for (s in 1:SS) {
     PR_TR[,,,s]       = qqq$posterior$PR_TR[s,1][[1]]
     xi[,,,s]          = qqq$posterior$xi[s,1][[1]]
   }

--- a/inst/tinytest/test_hmsh_thinning.R
+++ b/inst/tinytest/test_hmsh_thinning.R
@@ -1,0 +1,40 @@
+data(us_fiscal_lsuw)
+T = nrow(us_fiscal_lsuw) - 1
+
+set.seed(141)
+specification = suppressMessages(
+  specify_bsvar_hmsh$new(us_fiscal_lsuw, M = 2)
+)
+posterior = estimate(specification, S = 4, thin = 2, show_progress = FALSE)
+
+expect_equal(
+  dim(posterior$posterior$PR_TR),
+  c(2, 2, 3, 2),
+  info = "HMSH transition output contains only retained draws after thinning."
+)
+expect_equal(
+  dim(posterior$posterior$xi),
+  c(2, T, 3, 2),
+  info = "HMSH state output contains only retained draws after thinning."
+)
+expect_false(
+  anyNA(posterior$posterior$PR_TR) || anyNA(posterior$posterior$xi),
+  info = "HMSH retained state output contains no unfilled slices."
+)
+
+continued = estimate(posterior, S = 4, thin = 2, show_progress = FALSE)
+
+expect_equal(
+  dim(continued$posterior$PR_TR),
+  c(2, 2, 3, 2),
+  info = "Continuation reshapes only retained HMSH transition draws."
+)
+expect_equal(
+  dim(continued$posterior$xi),
+  c(2, T, 3, 2),
+  info = "Continuation reshapes only retained HMSH state draws."
+)
+expect_false(
+  anyNA(continued$posterior$PR_TR) || anyNA(continued$posterior$xi),
+  info = "Continuation retained state output contains no unfilled slices."
+)


### PR DESCRIPTION
This bug affects only HMSH estimation with `thin > 1`; `thin = 1` is unaffected.

Findings:
- **B14:** Use retained draws, `SS = S / thin`, to size and reshape `PR_TR` and `xi` in initial and continued estimation.

**Regression test:** `test_hmsh_thinning.R` checks retained dimensions, complete state slices, and continuation with `thin > 1`.
Audit: [PDF](https://mega.nz/file/PawkUBbT#Kx_kuCm-QZkV9vbDqKzCF-ewxUZzEuzKuTBDmdV4Fbw)